### PR TITLE
Fix issue where instance-terminator-group tag values were ignored

### DIFF
--- a/src/instance_terminator.js
+++ b/src/instance_terminator.js
@@ -77,7 +77,7 @@ function terminateOldestInstanceFromEachGrouped(autoscalingGroups) {
     instanceTerminatorGroupNames.forEach(function(instanceTerminatorGroupName) {
         promises.push(new Promise(function(resolve) {
 
-            const matchingAutoscalingGroups = autoscalingGroups.filter(item => containsTag(item['Tags'], 'instance-terminator-group', instanceTerminatorGroupName));
+            const matchingAutoscalingGroups = autoscalingGroups.filter(item => containsTagValue(item['Tags'], 'instance-terminator-group', instanceTerminatorGroupName));
             console.log('Attempting to terminate instance from: ' + instanceTerminatorGroupName);
 
             if (matchingAutoscalingGroups.length < 2) {
@@ -175,6 +175,13 @@ function terminateOldestInstanceFrom(matchingAutoscalingGroups) {
 function containsTag(tags, tagKey) {
     return tags.some(function (tag) {
         if (tag['Key'] == tagKey)
+            return true;
+    })
+}
+
+function containsTagValue(tags, tagKey, tagValue) {
+    return tags.some(function (tag) {
+        if (tag['Key'] == tagKey && tag['Value'] == tagValue)
             return true;
     })
 }

--- a/src/instance_terminator.js
+++ b/src/instance_terminator.js
@@ -118,7 +118,7 @@ function terminateOldestInstanceFrom(matchingAutoscalingGroups) {
             const instances = autoscalingGroup['Instances'];
             const healthyInstances = instances.filter(instance => instance['LifecycleState'] == 'InService' && instance['HealthStatus'] == 'Healthy');
 
-            if (healthyInstances.length < desiredCapacity) {
+            if (healthyInstances.length < desiredCapacity || desiredCapacity < 1) {
                 console.log('Too few healthy instances, ignoring.')
                 var response = {
                     result: 'not enough healthy instances in group'


### PR DESCRIPTION
Fix issue where instance-terminator-group tag values were ignored causing instances to be terminated across all grouped autoscaling groups.
Also fix minor issue with autoscaling groups with a size of zero.