### PR TITLE
Generate package on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,19 +16,24 @@ jobs:
       - run:
           name: unit-tests
           command: npm run test:unit
+      - run:
+          name: package
+          command: npm run package
+      - store_artifacts:
+          path: instance-terminator.zip
   release:
     machine: true
     steps:
       - add_ssh_keys
       - checkout
       - run:
-          name : patch-application
+          name: patch-application
           command: |
             git config --global user.email "circleci@wealthwizards.com"
             git config --global user.name "Circle CI"
             npm version patch -m "Release %s [ci skip]"
       - deploy:
-          name : deploy-git-changes
+          name: deploy-git-changes
           command: git push --follow-tags
 workflows:
   version: 2


### PR DESCRIPTION
Github changed the way they produced source code archives, so now we generate the package zip as part of the build and so that we can manually attach it to a github release.